### PR TITLE
Update test_district_repository.rb

### DIFF
--- a/test/test_district_repository.rb
+++ b/test/test_district_repository.rb
@@ -24,12 +24,12 @@ class TestDistrictRepository < TestHarness
 
     def test_it_returns_all_districts_matching_the_name_fragment
       assert_equal ['IDALIA SCHOOL DISTRICT RJ-3', 'WRAY SCHOOL DISTRICT RD-2'],
-                   repo.find_all_matching('DISTRICT R').map { |district| district.name }.sort
+                   repo.find_all_matching('DISTRICT R')
     end
 
     def test_it_matches_case_insensitive
       assert_equal ['COLORADO', 'COLORADO SPRINGS 11'],
-                   repo.find_all_matching('oRa').map { |district| district.name }.sort
+                   repo.find_all_matching('oRa')
     end
   end
 end


### PR DESCRIPTION
Find all matching should return the correct data by calling .keys if repo_hash is already formatted correctly. Ex: 

def find_all_matching(fragment)
    @districts_by_name.select { |name, district_data| name.include?(fragment.upcase) }.keys
    # recieves a String
    # returns either [] or one or more matches which contain the supplied name fragment, case insensitive
  end