### PR TITLE
Refute statewide highschool/k prediction

### DIFF
--- a/test/iteration_one_test.rb
+++ b/test/iteration_one_test.rb
@@ -50,7 +50,7 @@ class IterationOneTest < Minitest::Test
                                   :high_school_graduation => "./data/High school graduation rates.csv"}})
     ha = HeadcountAnalyst.new(dr)
 
-    assert ha.kindergarten_participation_correlates_with_high_school_graduation(:for => 'STATEWIDE')
+    refute ha.kindergarten_participation_correlates_with_high_school_graduation(:for => 'STATEWIDE')
   end
 
   def test_kindergarten_hs_prediction_multi_district


### PR DESCRIPTION
Talking to various groups and running against our own files, we found that the correlation between kindergarten and high school across the state is always 'false' not 'true' so the test_statewide_kindergarten_high_school_prediction should have a refute statement instead of assert.