### PR TITLE
Match spec for median household income

### DIFF
--- a/test/iteration_three_test.rb
+++ b/test/iteration_three_test.rb
@@ -7,7 +7,7 @@ require_relative "../../headcount/lib/economic_profile"
 
 class IterationThreeTest < Minitest::Test
   def test_economic_profile_basics
-    data = {:median_household_income => {2015 => 50000, 2014 => 60000},
+    data = {:median_household_income => {[2014, 2015] => 50000, [2013, 2014] => 60000},
             :children_in_poverty => {2012 => 0.1845},
             :free_or_reduced_price_lunch => {2014 => {:percentage => 0.023, :total => 100}},
             :title_i => {2015 => 0.543},


### PR DESCRIPTION
Matches the iteration 3 spec for using ranges for the median household income.